### PR TITLE
Refactor task validation from AJV to Zod and add MCP tool

### DIFF
--- a/mcp-server/src/tools/index.js
+++ b/mcp-server/src/tools/index.js
@@ -22,6 +22,7 @@ import { registerClearSubtasksTool } from './clear-subtasks.js';
 import { registerExpandAllTool } from './expand-all.js';
 import { registerRemoveDependencyTool } from './remove-dependency.js';
 import { registerValidateDependenciesTool } from './validate-dependencies.js';
+import { registerValidateTasksTool } from './validate-tasks.js';
 import { registerFixDependenciesTool } from './fix-dependencies.js';
 import { registerComplexityReportTool } from './complexity-report.js';
 import { registerAddDependencyTool } from './add-dependency.js';
@@ -76,10 +77,11 @@ export function registerTaskMasterTools(server) {
 		registerClearSubtasksTool(server);
 		registerMoveTaskTool(server);
 
-		// Group 6: Dependency Management
+		// Group 6: Dependency Management & Validation
 		registerAddDependencyTool(server);
 		registerRemoveDependencyTool(server);
 		registerValidateDependenciesTool(server);
+		registerValidateTasksTool(server);
 		registerFixDependenciesTool(server);
 
 		// Group 7: Tag Management

--- a/mcp-server/src/tools/validate-tasks.js
+++ b/mcp-server/src/tools/validate-tasks.js
@@ -1,0 +1,123 @@
+/**
+ * tools/validate-tasks.js
+ * Tool for validating tasks file structure and content
+ */
+
+import { z } from 'zod';
+import {
+	handleApiResult,
+	createErrorResponse,
+	withNormalizedProjectRoot
+} from './utils.js';
+import { findTasksPath } from '../core/utils/path-utils.js';
+import { validateTasksFile, validateTasksArray, formatAjvError } from '../../../scripts/modules/task-validator.js';
+import { readJSON } from '../../../scripts/modules/utils.js';
+
+/**
+ * Register the validateTasks tool with the MCP server
+ * @param {Object} server - FastMCP server instance
+ */
+export function registerValidateTasksTool(server) {
+	server.addTool({
+		name: 'validate_tasks',
+		description:
+			'Validates the structure and content of the tasks.json file or a specific tag within it.',
+		parameters: z.object({
+			file: z.string().optional().describe('Absolute path to the tasks file'),
+			projectRoot: z
+				.string()
+				.describe('The directory of the project. Must be an absolute path.'),
+			tag: z.string().optional().describe('Validate only the specified tag tasks array')
+		}),
+		execute: withNormalizedProjectRoot(async (args, { log, session }) => {
+			try {
+				log.info(`Validating tasks with args: ${JSON.stringify(args)}`);
+
+				// Use args.projectRoot directly (guaranteed by withNormalizedProjectRoot)
+				let tasksJsonPath;
+				try {
+					tasksJsonPath = findTasksPath(
+						{ projectRoot: args.projectRoot, file: args.file },
+						log
+					);
+				} catch (error) {
+					log.error(`Error finding tasks.json: ${error.message}`);
+					return createErrorResponse(
+						`Failed to find tasks.json: ${error.message}`
+					);
+				}
+
+				if (!tasksJsonPath) {
+					return createErrorResponse(
+						`Could not find tasks.json file in project: ${args.projectRoot}`
+					);
+				}
+
+				// Read the tasks file
+				const tasksData = readJSON(tasksJsonPath, args.projectRoot);
+				if (!tasksData) {
+					return createErrorResponse(
+						`Could not read tasks file at: ${tasksJsonPath}`
+					);
+				}
+
+				let result;
+				let validationTargetDescription;
+
+				if (args.tag) {
+					// Validate specific tag
+					validationTargetDescription = `tasks for tag '${args.tag}'`;
+					const tagToValidate = args.tag;
+					const fullData = tasksData._rawTaggedData || tasksData;
+
+					if (fullData && fullData[tagToValidate] && Array.isArray(fullData[tagToValidate].tasks)) {
+						result = validateTasksArray(fullData[tagToValidate].tasks);
+					} else {
+						return createErrorResponse(
+							`Tag '${tagToValidate}' not found or has no tasks array in ${tasksJsonPath}`
+						);
+					}
+				} else {
+					// Validate entire file structure
+					validationTargetDescription = `entire file structure of ${tasksJsonPath}`;
+					const fullData = tasksData._rawTaggedData || tasksData;
+					result = validateTasksFile(fullData);
+				}
+
+				if (result.isValid) {
+					const successMessage = `Validation successful for ${validationTargetDescription}.`;
+					log.info(successMessage);
+					return {
+						success: true,
+						data: {
+							message: successMessage,
+							isValid: true,
+							validationTarget: validationTargetDescription,
+							filePath: tasksJsonPath
+						}
+					};
+				} else {
+					const errorMessages = (result.errors || []).map(error => formatAjvError(error));
+					const failureMessage = `Validation failed for ${validationTargetDescription}`;
+					
+					log.error(`${failureMessage}: ${errorMessages.join('; ')}`);
+					
+					return {
+						success: false,
+						error: {
+							message: failureMessage,
+							isValid: false,
+							validationTarget: validationTargetDescription,
+							filePath: tasksJsonPath,
+							errors: errorMessages
+						}
+					};
+				}
+
+			} catch (error) {
+				log.error(`Error in validateTasks tool: ${error.message}`);
+				return createErrorResponse(error.message);
+			}
+		})
+	});
+}

--- a/scripts/modules/utils.js
+++ b/scripts/modules/utils.js
@@ -14,11 +14,30 @@ import * as gitUtils from './utils/git-utils.js';
 import {
 	COMPLEXITY_REPORT_FILE,
 	LEGACY_COMPLEXITY_REPORT_FILE,
-	LEGACY_CONFIG_FILE
+	LEGACY_CONFIG_FILE,
+	TASKMASTER_TASKS_FILE,
+	LEGACY_TASKS_FILE
 } from '../../src/constants/paths.js';
 
 // Global silent mode flag
 let silentMode = false;
+
+/**
+ * Checks if a file path represents a tasks file based on known patterns
+ * @param {string} filepath - The file path to check
+ * @returns {boolean} - True if the file is a tasks file
+ */
+function isTasksFile(filepath) {
+	if (!filepath) return false;
+	
+	// Normalize the path for comparison
+	const normalizedPath = path.normalize(filepath);
+	
+	// Check if it ends with the standard tasks file patterns
+	return normalizedPath.endsWith(TASKMASTER_TASKS_FILE) || 
+	       normalizedPath.endsWith(LEGACY_TASKS_FILE) ||
+	       normalizedPath.endsWith('tasks.json');
+}
 
 // --- Environment Variable Resolution Utility ---
 /**
@@ -252,8 +271,8 @@ function readJSON(filepath, projectRoot = null, tag = null) {
 		if (isDebug) {
 			console.log(`Successfully read JSON from ${filepath}`);
 		}
-		// Validate tasks.json content after reading
-		if (filepath.endsWith('tasks.json') && typeof data === 'object' && data !== null) {
+		// Validate tasks file content after reading
+		if (isTasksFile(filepath) && typeof data === 'object' && data !== null) {
 			const { isValid, errors } = validateTasksFile(data);
 			if (!isValid) {
 				errors.forEach(error => {


### PR DESCRIPTION
- Replace AJV with Zod for JSON schema validation in task-validator.js
- Convert all validation schemas to Zod format with proper type definitions
- Update error conversion to maintain AJV-compatible format for existing code
- Add isTasksFile() helper in utils.js using path constants instead of hardcoded strings
- Create validate-tasks MCP tool for validating tasks files and specific tags
- All existing tests pass with improved validation strictness
- CLI validate-tasks command continues to work with enhanced error reporting