### PR TITLE
fix: correct authType for Gemini CLI API key authentication

### DIFF
--- a/src/ai-providers/gemini-cli.js
+++ b/src/ai-providers/gemini-cli.js
@@ -63,7 +63,7 @@ export class GeminiCliProvider extends BaseAIProvider {
 			if (params.apiKey && params.apiKey !== 'gemini-cli-no-key-required') {
 				// API key provided - use it for compatibility
 				authOptions = {
-					authType: 'api-key',
+					authType: 'gemini-api-key',
 					apiKey: params.apiKey
 				};
 			} else {

--- a/tests/unit/ai-providers/gemini-cli.test.js
+++ b/tests/unit/ai-providers/gemini-cli.test.js
@@ -106,7 +106,7 @@ describe('GeminiCliProvider', () => {
 			expect(client).toBeDefined();
 			expect(typeof client).toBe('function');
 			expect(createGeminiProvider).toHaveBeenCalledWith({
-				authType: 'api-key',
+				authType: 'gemini-api-key',
 				apiKey: 'test-api-key'
 			});
 		});
@@ -129,7 +129,7 @@ describe('GeminiCliProvider', () => {
 
 			expect(client).toBeDefined();
 			expect(createGeminiProvider).toHaveBeenCalledWith({
-				authType: 'api-key',
+				authType: 'gemini-api-key',
 				apiKey: 'test-key',
 				baseURL: 'https://custom-endpoint.com'
 			});
@@ -423,7 +423,7 @@ describe('GeminiCliProvider', () => {
 				model: expect.objectContaining({
 					id: 'gemini-2.0-flash-exp',
 					authOptions: expect.objectContaining({
-						authType: 'api-key',
+						authType: 'gemini-api-key',
 						apiKey: 'test-key'
 					})
 				}),
@@ -621,11 +621,11 @@ describe('GeminiCliProvider', () => {
 	// since dynamic imports are difficult to mock properly in unit tests
 
 	describe('authentication scenarios', () => {
-		it('should use api-key auth type with API key', async () => {
+		it('should use gemini-api-key auth type with API key', async () => {
 			await provider.getClient({ apiKey: 'gemini-test-key' });
 
 			expect(createGeminiProvider).toHaveBeenCalledWith({
-				authType: 'api-key',
+				authType: 'gemini-api-key',
 				apiKey: 'gemini-test-key'
 			});
 		});


### PR DESCRIPTION
## Summary
- Fixes the "Failed to initialize Gemini model: Error: Error creating contentGenerator: Unsupported authType: undefined" error
- Changes authType from 'api-key' to 'gemini-api-key' for API key authentication

## Root Cause
The ai-sdk-provider-gemini-cli package's initializeGeminiClient function only recognizes these authType values:
- 'gemini-api-key' → maps to AuthType.USE_GEMINI
- 'oauth-personal' → maps to AuthType.LOGIN_WITH_GOOGLE_PERSONAL  
- 'vertex-ai' → maps to AuthType.USE_VERTEX_AI

Our implementation was using 'api-key' which didn't match any condition, causing authType to become undefined and triggering the error.

## Test plan
- [x] All 46 Gemini CLI provider tests pass
- [x] All 64 AI provider tests pass
- [x] Both OAuth and API key authentication work correctly
- [x] No breaking changes or regressions

🤖 Generated with [Claude Code](https://claude.ai/code)